### PR TITLE
drop v0.4 support to prevent future test additions from causing v0.4 failures …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 Compat 0.7.15


### PR DESCRIPTION
…on old tags of downstream packages