### PR TITLE
Add derivative rules and drop v0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-Compat 0.7.15
+julia 0.6-

--- a/src/DiffBase.jl
+++ b/src/DiffBase.jl
@@ -1,11 +1,10 @@
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
 
 module DiffBase
 
-using Compat
-
 include("results.jl")
 include("testfuncs.jl")
+include("rules.jl")
 
 ######################
 # Test Function Sets #

--- a/src/results.jl
+++ b/src/results.jl
@@ -2,7 +2,7 @@
 # DiffResult #
 ##############
 
-struct DiffResult{O,V,D<:Tuple}
+mutable struct DiffResult{O,V,D<:Tuple}
     value::V
     derivs::D # ith element = ith-order derivative
     function DiffResult{O,V,D}(value::V, derivs::NTuple{O,Any}) where {O,V,D}

--- a/src/results.jl
+++ b/src/results.jl
@@ -2,10 +2,10 @@
 # DiffResult #
 ##############
 
-@compat type DiffResult{O,V,D<:Tuple}
+struct DiffResult{O,V,D<:Tuple}
     value::V
     derivs::D # ith element = ith-order derivative
-    function (::Type{DiffResult{O,V,D}}){O,V,D}(value::V, derivs::NTuple{O,Any})
+    function DiffResult{O,V,D}(value::V, derivs::NTuple{O,Any}) where {O,V,D}
         return new{O,V,D}(value, derivs)
     end
 end
@@ -80,7 +80,7 @@ HessianResult(x::AbstractArray) = DiffResult(first(x), similar(x), similar(x, le
 Base.eltype(r::DiffResult) = eltype(typeof(r))
 Base.eltype{O,V,D}(::Type{DiffResult{O,V,D}}) = eltype(V)
 
-@compat Base.:(==)(a::DiffResult, b::DiffResult) = a.value == b.value && a.derivs == b.derivs
+Base.:(==)(a::DiffResult, b::DiffResult) = a.value == b.value && a.derivs == b.derivs
 
 Base.copy(r::DiffResult) = DiffResult(copy(r.value), map(copy, r.derivs))
 

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -8,7 +8,7 @@ end
 
 const TODO = Symbol[:abs, :mod, :eta, :zeta, :airyaix, :airyaiprimex, :airybix,
                     :airybiprimex, :besseljx, :besselyx, :besselix, :besselkx, :besselh,
-                    :besselhx, :hankelh1x, :hankelh2, :hankelh2x, :polygamma]
+                    :besselhx, :hankelh1x, :hankelh2, :hankelh2x]
 
 ################
 # General Math #
@@ -109,9 +109,10 @@ const TODO = Symbol[:abs, :mod, :eta, :zeta, :airyaix, :airyaiprimex, :airybix,
 # binary #
 #--------#
 
-@diffrule(:besselj)(ν, x)  = :(NaN), :(  (besselj($ν - 1, $x) - besselj($ν + 1, $x)) / 2   )
-@diffrule(:besseli)(ν, x)  = :(NaN), :(  (besseli($ν - 1, $x) + besseli($ν + 1, $x)) / 2   )
-@diffrule(:bessely)(ν, x)  = :(NaN), :(  (bessely($ν - 1, $x) - bessely($ν + 1, $x)) / 2   )
-@diffrule(:besselk)(ν, x)  = :(NaN), :( -(besselk($ν - 1, $x) + besselk($ν + 1, $x)) / 2   )
-@diffrule(:hankelh1)(ν, x) = :(NaN), :(  (hankelh1($ν - 1, $x) - hankelh1($ν + 1, $x)) / 2 )
-@diffrule(:hankelh2)(ν, x) = :(NaN), :(  (hankelh2($ν - 1, $x) - hankelh2($ν + 1, $x)) / 2 )
+@diffrule(:besselj)(ν, x)   = :NaN, :(  (besselj($ν - 1, $x) - besselj($ν + 1, $x)) / 2   )
+@diffrule(:besseli)(ν, x)   = :NaN, :(  (besseli($ν - 1, $x) + besseli($ν + 1, $x)) / 2   )
+@diffrule(:bessely)(ν, x)   = :NaN, :(  (bessely($ν - 1, $x) - bessely($ν + 1, $x)) / 2   )
+@diffrule(:besselk)(ν, x)   = :NaN, :( -(besselk($ν - 1, $x) + besselk($ν + 1, $x)) / 2   )
+@diffrule(:hankelh1)(ν, x)  = :NaN, :(  (hankelh1($ν - 1, $x) - hankelh1($ν + 1, $x)) / 2 )
+@diffrule(:hankelh2)(ν, x)  = :NaN, :(  (hankelh2($ν - 1, $x) - hankelh2($ν + 1, $x)) / 2 )
+@diffrule(:polygamma)(m, x) = :NaN, :(  polygamma($m + 1, $x)                             )

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -6,7 +6,9 @@ end
 
 (::Type{DiffRule{F}})(args...) where {F} = error("derivative not yet defined for $F")
 
-const TODO = Symbol[:abs, :eta, :zeta, :airyaix, :airyaiprimex, :airybix, :airybiprimex, :besselh, :besselhx]
+const TODO = Symbol[:abs, :mod, :eta, :zeta, :airyaix, :airyaiprimex, :airybix,
+                    :airybiprimex, :besseljx, :besselyx, :besselix, :besselkx, :besselh,
+                    :besselhx, :hankelh1x, :hankelh2, :hankelh2x, :polygamma]
 
 ################
 # General Math #
@@ -104,10 +106,12 @@ const TODO = Symbol[:abs, :eta, :zeta, :airyaix, :airyaiprimex, :airybix, :airyb
 @diffrule(:bessely0)(x)    = :( -bessely1($x)                        )
 @diffrule(:bessely1)(x)    = :(  (bessely0($x) - bessely(2, $x)) / 2 )
 
-
-
 # binary #
 #--------#
 
-# ternary #
-#---------#
+@diffrule(:besselj)(ν, x)  = :(NaN), :(  (besselj($ν - 1, $x) - besselj($ν + 1, $x)) / 2   )
+@diffrule(:besseli)(ν, x)  = :(NaN), :(  (besseli($ν - 1, $x) + besseli($ν + 1, $x)) / 2   )
+@diffrule(:bessely)(ν, x)  = :(NaN), :(  (bessely($ν - 1, $x) - bessely($ν + 1, $x)) / 2   )
+@diffrule(:besselk)(ν, x)  = :(NaN), :( -(besselk($ν - 1, $x) + besselk($ν + 1, $x)) / 2   )
+@diffrule(:hankelh1)(ν, x) = :(NaN), :(  (hankelh1($ν - 1, $x) - hankelh1($ν + 1, $x)) / 2 )
+@diffrule(:hankelh2)(ν, x) = :(NaN), :(  (hankelh2($ν - 1, $x) - hankelh2($ν + 1, $x)) / 2 )

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,14 +1,24 @@
+const DEFINED_DIFFRULES = Tuple{Symbol,Int}[]
+
 struct DiffRule{F} end
 
-macro diffrule(f)
-    return :((::Type{DiffRule{$f}}))
+(::Type{DiffRule{F}})(args...) where {F} = error("no derivative rule defined for $F with arguments $args")
+
+macro define_diffrule(def)
+    @assert isa(def, Expr) && def.head == :(=)
+    rhs = def.args[1]
+    lhs = def.args[2]
+    @assert isa(rhs, Expr) && rhs.head == :call
+    f = rhs.args[1]
+    args = rhs.args[2:end]
+    rhs.args[1] = :(::Type{DiffRule{$(Expr(:quote, f))}})
+    push!(DEFINED_DIFFRULES, (f, length(args)))
+    return esc(def)
 end
 
-(::Type{DiffRule{F}})(args...) where {F} = error("derivative not yet defined for $F")
+diffrule(f::Symbol, args...) = DiffRule{f}(args...)
 
-const TODO = Symbol[:abs, :mod, :eta, :zeta, :airyaix, :airyaiprimex, :airybix,
-                    :airybiprimex, :besseljx, :besselyx, :besselix, :besselkx, :besselh,
-                    :besselhx, :hankelh1x, :hankelh2, :hankelh2x]
+hasdiffrule(f::Symbol, arity::Int) = in((f, arity), DEFINED_DIFFRULES)
 
 ################
 # General Math #
@@ -17,68 +27,74 @@ const TODO = Symbol[:abs, :mod, :eta, :zeta, :airyaix, :airyaiprimex, :airybix,
 # unary #
 #-------#
 
-@diffrule(:+)(x)       = :(  1                                  )
-@diffrule(:-)(x)       = :( -1                                  )
-@diffrule(:sqrt)(x)    = :(  inv(2 * sqrt($x))                  )
-@diffrule(:cbrt)(x)    = :(  inv(3 * cbrt($x)^2)                )
-@diffrule(:abs2)(x)    = :(  $x + $x                            )
-@diffrule(:inv)(x)     = :( -abs2(inv($x))                      )
-@diffrule(:log)(x)     = :(  inv($x)                            )
-@diffrule(:log10)(x)   = :(  inv($x) / log(10)                  )
-@diffrule(:log2)(x)    = :(  inv($x) / log(2)                   )
-@diffrule(:log1p)(x)   = :(  inv($x + 1)                        )
-@diffrule(:exp)(x)     = :(  exp($x)                            )
-@diffrule(:exp2)(x)    = :(  exp2($x) * log(2)                  )
-@diffrule(:expm1)(x)   = :(  exp($x)                            )
-@diffrule(:sin)(x)     = :(  cos($x)                            )
-@diffrule(:cos)(x)     = :( -sin($x)                            )
-@diffrule(:tan)(x)     = :(  1 + tan($x)^2                      )
-@diffrule(:sec)(x)     = :(  sec($x) * tan($x)                  )
-@diffrule(:csc)(x)     = :( -csc($x) * cot($x)                  )
-@diffrule(:cot)(x)     = :( -(1 + cot($x)^2)                    )
-@diffrule(:sind)(x)    = :(  (π / 180) * cosd($x)               )
-@diffrule(:cosd)(x)    = :( -(π / 180) * sind($x)               )
-@diffrule(:tand)(x)    = :(  (π / 180) * (1 + tand($x)^2)       )
-@diffrule(:secd)(x)    = :(  (π / 180) * secd($x) * tand($x)    )
-@diffrule(:cscd)(x)    = :( -(π / 180) * cscd($x) * cotd($x)    )
-@diffrule(:cotd)(x)    = :( -(π / 180) * (1 + cotd($x)^2)       )
-@diffrule(:asin)(x)    = :(  inv(sqrt(1 - $x^2))                )
-@diffrule(:acos)(x)    = :( -inv(sqrt(1 - $x^2))                )
-@diffrule(:atan)(x)    = :(  inv(1 + $x^2)                      )
-@diffrule(:asec)(x)    = :(  inv(abs($x) * sqrt($x^2 - 1))      )
-@diffrule(:acsc)(x)    = :( -inv(abs($x) * sqrt($x^2 - 1))      )
-@diffrule(:acot)(x)    = :( -inv(1 + $x^2)                      )
-@diffrule(:asind)(x)   = :(  180 / π / sqrt(1 - $x^2)           )
-@diffrule(:acosd)(x)   = :( -180 / π / sqrt(1 - $x^2)           )
-@diffrule(:atand)(x)   = :(  180 / π / (1 + $x^2)               )
-@diffrule(:asecd)(x)   = :(  180 / π / abs($x) / sqrt($x^2 - 1) )
-@diffrule(:acscd)(x)   = :( -180 / π / abs($x) / sqrt($x^2 - 1) )
-@diffrule(:acotd)(x)   = :( -180 / π / (1 + $x^2)               )
-@diffrule(:sinh)(x)    = :(  cosh($x)                           )
-@diffrule(:cosh)(x)    = :(  sinh($x)                           )
-@diffrule(:tanh)(x)    = :(  sech($x)^2                         )
-@diffrule(:sech)(x)    = :( -tanh($x) * sech($x)                )
-@diffrule(:csch)(x)    = :( -coth($x) * csch($x)                )
-@diffrule(:coth)(x)    = :( -(csch($x)^2)                       )
-@diffrule(:asinh)(x)   = :(  inv(sqrt($x^2 + 1))                )
-@diffrule(:acosh)(x)   = :(  inv(sqrt($x^2 - 1))                )
-@diffrule(:atanh)(x)   = :(  inv(1 - $x^2)                      )
-@diffrule(:asech)(x)   = :( -inv($x * sqrt(1 - $x^2))           )
-@diffrule(:acsch)(x)   = :( -inv(abs($x) * sqrt(1 + $x^2))      )
-@diffrule(:acoth)(x)   = :(  inv(1 - $x^2)                      )
-@diffrule(:deg2rad)(x) = :(  π / 180                            )
-@diffrule(:rad2deg)(x) = :(  180 / π                            )
-@diffrule(:gamma)(x)   = :(  digamma($x) * gamma($x)            )
-@diffrule(:lgamma)(x)  = :(  digamma($x)                        )
+@define_diffrule +(x)       = :(  1                                  )
+@define_diffrule -(x)       = :( -1                                  )
+@define_diffrule sqrt(x)    = :(  inv(2 * sqrt($x))                  )
+@define_diffrule cbrt(x)    = :(  inv(3 * cbrt($x)^2)                )
+@define_diffrule abs2(x)    = :(  $x + $x                            )
+@define_diffrule inv(x)     = :( -abs2(inv($x))                      )
+@define_diffrule log(x)     = :(  inv($x)                            )
+@define_diffrule log10(x)   = :(  inv($x) / log(10)                  )
+@define_diffrule log2(x)    = :(  inv($x) / log(2)                   )
+@define_diffrule log1p(x)   = :(  inv($x + 1)                        )
+@define_diffrule exp(x)     = :(  exp($x)                            )
+@define_diffrule exp2(x)    = :(  exp2($x) * log(2)                  )
+@define_diffrule expm1(x)   = :(  exp($x)                            )
+@define_diffrule sin(x)     = :(  cos($x)                            )
+@define_diffrule cos(x)     = :( -sin($x)                            )
+@define_diffrule tan(x)     = :(  1 + tan($x)^2                      )
+@define_diffrule sec(x)     = :(  sec($x) * tan($x)                  )
+@define_diffrule csc(x)     = :( -csc($x) * cot($x)                  )
+@define_diffrule cot(x)     = :( -(1 + cot($x)^2)                    )
+@define_diffrule sind(x)    = :(  (π / 180) * cosd($x)               )
+@define_diffrule cosd(x)    = :( -(π / 180) * sind($x)               )
+@define_diffrule tand(x)    = :(  (π / 180) * (1 + tand($x)^2)       )
+@define_diffrule secd(x)    = :(  (π / 180) * secd($x) * tand($x)    )
+@define_diffrule cscd(x)    = :( -(π / 180) * cscd($x) * cotd($x)    )
+@define_diffrule cotd(x)    = :( -(π / 180) * (1 + cotd($x)^2)       )
+@define_diffrule asin(x)    = :(  inv(sqrt(1 - $x^2))                )
+@define_diffrule acos(x)    = :( -inv(sqrt(1 - $x^2))                )
+@define_diffrule atan(x)    = :(  inv(1 + $x^2)                      )
+@define_diffrule asec(x)    = :(  inv(abs($x) * sqrt($x^2 - 1))      )
+@define_diffrule acsc(x)    = :( -inv(abs($x) * sqrt($x^2 - 1))      )
+@define_diffrule acot(x)    = :( -inv(1 + $x^2)                      )
+@define_diffrule asind(x)   = :(  180 / π / sqrt(1 - $x^2)           )
+@define_diffrule acosd(x)   = :( -180 / π / sqrt(1 - $x^2)           )
+@define_diffrule atand(x)   = :(  180 / π / (1 + $x^2)               )
+@define_diffrule asecd(x)   = :(  180 / π / abs($x) / sqrt($x^2 - 1) )
+@define_diffrule acscd(x)   = :( -180 / π / abs($x) / sqrt($x^2 - 1) )
+@define_diffrule acotd(x)   = :( -180 / π / (1 + $x^2)               )
+@define_diffrule sinh(x)    = :(  cosh($x)                           )
+@define_diffrule cosh(x)    = :(  sinh($x)                           )
+@define_diffrule tanh(x)    = :(  sech($x)^2                         )
+@define_diffrule sech(x)    = :( -tanh($x) * sech($x)                )
+@define_diffrule csch(x)    = :( -coth($x) * csch($x)                )
+@define_diffrule coth(x)    = :( -(csch($x)^2)                       )
+@define_diffrule asinh(x)   = :(  inv(sqrt($x^2 + 1))                )
+@define_diffrule acosh(x)   = :(  inv(sqrt($x^2 - 1))                )
+@define_diffrule atanh(x)   = :(  inv(1 - $x^2)                      )
+@define_diffrule asech(x)   = :( -inv($x * sqrt(1 - $x^2))           )
+@define_diffrule acsch(x)   = :( -inv(abs($x) * sqrt(1 + $x^2))      )
+@define_diffrule acoth(x)   = :(  inv(1 - $x^2)                      )
+@define_diffrule deg2rad(x) = :(  π / 180                            )
+@define_diffrule rad2deg(x) = :(  180 / π                            )
+@define_diffrule gamma(x)   = :(  digamma($x) * gamma($x)            )
+@define_diffrule lgamma(x)  = :(  digamma($x)                        )
 
 # binary #
 #--------#
 
-@diffrule(:+)(x, y) = :(1),                  :(1)
-@diffrule(:-)(x, y) = :(1),                  :(-1)
-@diffrule(:*)(x, y) = :($y),                 :($x)
-@diffrule(:/)(x, y) = :(inv($y)),            :(-$x / ($y^2))
-@diffrule(:^)(x, y) = :($y * ($x^($y - 1))), :(($x^$y) * log($x))
+@define_diffrule +(x, y) = :(1),                  :(1)
+@define_diffrule -(x, y) = :(1),                  :(-1)
+@define_diffrule *(x, y) = :($y),                 :($x)
+@define_diffrule /(x, y) = :(inv($y)),            :(-$x / ($y^2))
+@define_diffrule ^(x, y) = :($y * ($x^($y - 1))), :(($x^$y) * log($x))
+
+# TODO:
+#
+# mod
+# hypot
+# atan2
 
 ####################
 # SpecialFunctions #
@@ -87,32 +103,62 @@ const TODO = Symbol[:abs, :mod, :eta, :zeta, :airyaix, :airyaiprimex, :airybix,
 # unary #
 #-------#
 
-@diffrule(:erf)(x)         = :(  (2 / sqrt(π)) * exp(-$x * $x)       )
-@diffrule(:erfinv)(x)      = :(  (sqrt(π) / 2) * exp(erfinv($x)^2)   )
-@diffrule(:erfc)(x)        = :( -(2 / sqrt(π)) * exp(-$x * $x)       )
-@diffrule(:erfcinv)(x)     = :( -(sqrt(π) / 2) * exp(erfinv($x)^2)   )
-@diffrule(:erfi)(x)        = :(  (2 / sqrt(π)) * exp($x * $x)        )
-@diffrule(:erfcx)(x)       = :(  (2 * x * erfcx($x)) - (2 / sqrt(π)) )
-@diffrule(:dawson)(x)      = :(  1 - (2 * x * dawson($x))            )
-@diffrule(:digamma)(x)     = :(  trigamma($x)                        )
-@diffrule(:invdigamma)(x)  = :(  inv(trigamma(invdigamma($x)))       )
-@diffrule(:trigamma)(x)    = :(  polygamma(2, $x)                    )
-@diffrule(:airyai)(x)      = :(  airyaiprime($x)                     )
-@diffrule(:airyaiprime)(x) = :(  $x * airyai($x)                     )
-@diffrule(:airybi)(x)      = :(  airybiprime($x)                     )
-@diffrule(:airybiprime)(x) = :(  $x * airybi($x)                     )
-@diffrule(:besselj0)(x)    = :( -besselj1($x)                        )
-@diffrule(:besselj1)(x)    = :(  (besselj0($x) - besselj(2, $x)) / 2 )
-@diffrule(:bessely0)(x)    = :( -bessely1($x)                        )
-@diffrule(:bessely1)(x)    = :(  (bessely0($x) - bessely(2, $x)) / 2 )
+@define_diffrule erf(x)         = :(  (2 / sqrt(π)) * exp(-$x * $x)       )
+@define_diffrule erfinv(x)      = :(  (sqrt(π) / 2) * exp(erfinv($x)^2)   )
+@define_diffrule erfc(x)        = :( -(2 / sqrt(π)) * exp(-$x * $x)       )
+@define_diffrule erfcinv(x)     = :( -(sqrt(π) / 2) * exp(erfinv($x)^2)   )
+@define_diffrule erfi(x)        = :(  (2 / sqrt(π)) * exp($x * $x)        )
+@define_diffrule erfcx(x)       = :(  (2 * x * erfcx($x)) - (2 / sqrt(π)) )
+@define_diffrule dawson(x)      = :(  1 - (2 * x * dawson($x))            )
+@define_diffrule digamma(x)     = :(  trigamma($x)                        )
+@define_diffrule invdigamma(x)  = :(  inv(trigamma(invdigamma($x)))       )
+@define_diffrule trigamma(x)    = :(  polygamma(2, $x)                    )
+@define_diffrule airyai(x)      = :(  airyaiprime($x)                     )
+@define_diffrule airyaiprime(x) = :(  $x * airyai($x)                     )
+@define_diffrule airybi(x)      = :(  airybiprime($x)                     )
+@define_diffrule airybiprime(x) = :(  $x * airybi($x)                     )
+@define_diffrule besselj0(x)    = :( -besselj1($x)                        )
+@define_diffrule besselj1(x)    = :(  (besselj0($x) - besselj(2, $x)) / 2 )
+@define_diffrule bessely0(x)    = :( -bessely1($x)                        )
+@define_diffrule bessely1(x)    = :(  (bessely0($x) - bessely(2, $x)) / 2 )
+
+# TODO:
+#
+# eta
+# zeta
+# airyaix
+# airyaiprimex
+# airybix
+# airybiprimex
 
 # binary #
 #--------#
 
-@diffrule(:besselj)(ν, x)   = :NaN, :(  (besselj($ν - 1, $x) - besselj($ν + 1, $x)) / 2   )
-@diffrule(:besseli)(ν, x)   = :NaN, :(  (besseli($ν - 1, $x) + besseli($ν + 1, $x)) / 2   )
-@diffrule(:bessely)(ν, x)   = :NaN, :(  (bessely($ν - 1, $x) - bessely($ν + 1, $x)) / 2   )
-@diffrule(:besselk)(ν, x)   = :NaN, :( -(besselk($ν - 1, $x) + besselk($ν + 1, $x)) / 2   )
-@diffrule(:hankelh1)(ν, x)  = :NaN, :(  (hankelh1($ν - 1, $x) - hankelh1($ν + 1, $x)) / 2 )
-@diffrule(:hankelh2)(ν, x)  = :NaN, :(  (hankelh2($ν - 1, $x) - hankelh2($ν + 1, $x)) / 2 )
-@diffrule(:polygamma)(m, x) = :NaN, :(  polygamma($m + 1, $x)                             )
+@define_diffrule besselj(ν, x)   = :NaN, :(  (besselj($ν - 1, $x) - besselj($ν + 1, $x)) / 2   )
+@define_diffrule besseli(ν, x)   = :NaN, :(  (besseli($ν - 1, $x) + besseli($ν + 1, $x)) / 2   )
+@define_diffrule bessely(ν, x)   = :NaN, :(  (bessely($ν - 1, $x) - bessely($ν + 1, $x)) / 2   )
+@define_diffrule besselk(ν, x)   = :NaN, :( -(besselk($ν - 1, $x) + besselk($ν + 1, $x)) / 2   )
+@define_diffrule hankelh1(ν, x)  = :NaN, :(  (hankelh1($ν - 1, $x) - hankelh1($ν + 1, $x)) / 2 )
+@define_diffrule hankelh2(ν, x)  = :NaN, :(  (hankelh2($ν - 1, $x) - hankelh2($ν + 1, $x)) / 2 )
+@define_diffrule polygamma(m, x) = :NaN, :(  polygamma($m + 1, $x)                             )
+
+# TODO:
+#
+# zeta
+# besseljx
+# besselyx
+# besselix
+# besselkx
+# besselh
+# besselhx
+# hankelh1x
+# hankelh2
+# hankelh2x
+
+# ternary #
+#---------#
+
+# TODO:
+#
+# besselh
+# besselhx

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -1,0 +1,113 @@
+struct DiffRule{F} end
+
+macro diffrule(f)
+    return :((::Type{DiffRule{$f}}))
+end
+
+(::Type{DiffRule{F}})(args...) where {F} = error("derivative not yet defined for $F")
+
+const TODO = Symbol[:abs, :eta, :zeta, :airyaix, :airyaiprimex, :airybix, :airybiprimex, :besselh, :besselhx]
+
+################
+# General Math #
+################
+
+# unary #
+#-------#
+
+@diffrule(:+)(x)       = :(  1                                  )
+@diffrule(:-)(x)       = :( -1                                  )
+@diffrule(:sqrt)(x)    = :(  inv(2 * sqrt($x))                  )
+@diffrule(:cbrt)(x)    = :(  inv(3 * cbrt($x)^2)                )
+@diffrule(:abs2)(x)    = :(  $x + $x                            )
+@diffrule(:inv)(x)     = :( -abs2(inv($x))                      )
+@diffrule(:log)(x)     = :(  inv($x)                            )
+@diffrule(:log10)(x)   = :(  inv($x) / log(10)                  )
+@diffrule(:log2)(x)    = :(  inv($x) / log(2)                   )
+@diffrule(:log1p)(x)   = :(  inv($x + 1)                        )
+@diffrule(:exp)(x)     = :(  exp($x)                            )
+@diffrule(:exp2)(x)    = :(  exp2($x) * log(2)                  )
+@diffrule(:expm1)(x)   = :(  exp($x)                            )
+@diffrule(:sin)(x)     = :(  cos($x)                            )
+@diffrule(:cos)(x)     = :( -sin($x)                            )
+@diffrule(:tan)(x)     = :(  1 + tan($x)^2                      )
+@diffrule(:sec)(x)     = :(  sec($x) * tan($x)                  )
+@diffrule(:csc)(x)     = :( -csc($x) * cot($x)                  )
+@diffrule(:cot)(x)     = :( -(1 + cot($x)^2)                    )
+@diffrule(:sind)(x)    = :(  (π / 180) * cosd($x)               )
+@diffrule(:cosd)(x)    = :( -(π / 180) * sind($x)               )
+@diffrule(:tand)(x)    = :(  (π / 180) * (1 + tand($x)^2)       )
+@diffrule(:secd)(x)    = :(  (π / 180) * secd($x) * tand($x)    )
+@diffrule(:cscd)(x)    = :( -(π / 180) * cscd($x) * cotd($x)    )
+@diffrule(:cotd)(x)    = :( -(π / 180) * (1 + cotd($x)^2)       )
+@diffrule(:asin)(x)    = :(  inv(sqrt(1 - $x^2))                )
+@diffrule(:acos)(x)    = :( -inv(sqrt(1 - $x^2))                )
+@diffrule(:atan)(x)    = :(  inv(1 + $x^2)                      )
+@diffrule(:asec)(x)    = :(  inv(abs($x) * sqrt($x^2 - 1))      )
+@diffrule(:acsc)(x)    = :( -inv(abs($x) * sqrt($x^2 - 1))      )
+@diffrule(:acot)(x)    = :( -inv(1 + $x^2)                      )
+@diffrule(:asind)(x)   = :(  180 / π / sqrt(1 - $x^2)           )
+@diffrule(:acosd)(x)   = :( -180 / π / sqrt(1 - $x^2)           )
+@diffrule(:atand)(x)   = :(  180 / π / (1 + $x^2)               )
+@diffrule(:asecd)(x)   = :(  180 / π / abs($x) / sqrt($x^2 - 1) )
+@diffrule(:acscd)(x)   = :( -180 / π / abs($x) / sqrt($x^2 - 1) )
+@diffrule(:acotd)(x)   = :( -180 / π / (1 + $x^2)               )
+@diffrule(:sinh)(x)    = :(  cosh($x)                           )
+@diffrule(:cosh)(x)    = :(  sinh($x)                           )
+@diffrule(:tanh)(x)    = :(  sech($x)^2                         )
+@diffrule(:sech)(x)    = :( -tanh($x) * sech($x)                )
+@diffrule(:csch)(x)    = :( -coth($x) * csch($x)                )
+@diffrule(:coth)(x)    = :( -(csch($x)^2)                       )
+@diffrule(:asinh)(x)   = :(  inv(sqrt($x^2 + 1))                )
+@diffrule(:acosh)(x)   = :(  inv(sqrt($x^2 - 1))                )
+@diffrule(:atanh)(x)   = :(  inv(1 - $x^2)                      )
+@diffrule(:asech)(x)   = :( -inv($x * sqrt(1 - $x^2))           )
+@diffrule(:acsch)(x)   = :( -inv(abs($x) * sqrt(1 + $x^2))      )
+@diffrule(:acoth)(x)   = :(  inv(1 - $x^2)                      )
+@diffrule(:deg2rad)(x) = :(  π / 180                            )
+@diffrule(:rad2deg)(x) = :(  180 / π                            )
+@diffrule(:gamma)(x)   = :(  digamma($x) * gamma($x)            )
+@diffrule(:lgamma)(x)  = :(  digamma($x)                        )
+
+# binary #
+#--------#
+
+@diffrule(:+)(x, y) = :(1),                  :(1)
+@diffrule(:-)(x, y) = :(1),                  :(-1)
+@diffrule(:*)(x, y) = :($y),                 :($x)
+@diffrule(:/)(x, y) = :(inv($y)),            :(-$x / ($y^2))
+@diffrule(:^)(x, y) = :($y * ($x^($y - 1))), :(($x^$y) * log($x))
+
+####################
+# SpecialFunctions #
+####################
+
+# unary #
+#-------#
+
+@diffrule(:erf)(x)         = :(  (2 / sqrt(π)) * exp(-$x * $x)       )
+@diffrule(:erfinv)(x)      = :(  (sqrt(π) / 2) * exp(erfinv($x)^2)   )
+@diffrule(:erfc)(x)        = :( -(2 / sqrt(π)) * exp(-$x * $x)       )
+@diffrule(:erfcinv)(x)     = :( -(sqrt(π) / 2) * exp(erfinv($x)^2)   )
+@diffrule(:erfi)(x)        = :(  (2 / sqrt(π)) * exp($x * $x)        )
+@diffrule(:erfcx)(x)       = :(  (2 * x * erfcx($x)) - (2 / sqrt(π)) )
+@diffrule(:dawson)(x)      = :(  1 - (2 * x * dawson($x))            )
+@diffrule(:digamma)(x)     = :(  trigamma($x)                        )
+@diffrule(:invdigamma)(x)  = :(  inv(trigamma(invdigamma($x)))       )
+@diffrule(:trigamma)(x)    = :(  polygamma(2, $x)                    )
+@diffrule(:airyai)(x)      = :(  airyaiprime($x)                     )
+@diffrule(:airyaiprime)(x) = :(  $x * airyai($x)                     )
+@diffrule(:airybi)(x)      = :(  airybiprime($x)                     )
+@diffrule(:airybiprime)(x) = :(  $x * airybi($x)                     )
+@diffrule(:besselj0)(x)    = :( -besselj1($x)                        )
+@diffrule(:besselj1)(x)    = :(  (besselj0($x) - besselj(2, $x)) / 2 )
+@diffrule(:bessely0)(x)    = :( -bessely1($x)                        )
+@diffrule(:bessely1)(x)    = :(  (bessely0($x) - bessely(2, $x)) / 2 )
+
+
+
+# binary #
+#--------#
+
+# ternary #
+#---------#

--- a/src/testfuncs.jl
+++ b/src/testfuncs.jl
@@ -61,7 +61,7 @@ rosenbrock_3(x) = sum(map((i, j) -> (1 - j)^2 + 100*(i - j^2)^2, x[2:end], x[1:e
 function rosenbrock_4(x)
     t1 = (1 + x[1:end-1]).^2
     t2 = x[2:end] + (x[1:end-1]).^2
-    return sum(t1 + 100 * (@compat(abs.(t2)).^2))
+    return sum(t1 + 100 * (abs.(t2)).^2)
 end
 
 function ackley(x)
@@ -88,7 +88,7 @@ mat2num_1(x) = det(first(x) * inv(x * x) + x)
 function mat2num_2(x)
     a = reshape(x, length(x), 1)
     b = reshape(copy(x), 1, length(x))
-    return trace(@compat(log.((1 .+ (a * b)) .+ a .- b)))
+    return trace(log.((1 .+ (a * b)) .+ a .- b))
 end
 
 function mat2num_3(x)
@@ -98,16 +98,16 @@ function mat2num_3(x)
     return sum(map(n -> sqrt(abs(n) + n^2) * 0.5, A))
 end
 
-mat2num_4(x) = mean(sum(@compat(sin.(x)) * x, 2))
+mat2num_4(x) = mean(sum(sin.(x) * x, 2))
 
-softmax(x) = sum(@compat(exp.(x)) ./ sum(@compat(exp.(x)), 2))
+softmax(x) = sum(exp.(x) ./ sum(exp.(x), 2))
 
 ###########################################
 # f(::Matrix, ::Matrix, ::Matrix)::Number #
 ###########################################
 
-relu(x) = @compat(log.(1.0 .+ @compat(exp.(x))))
-sigmoid(n) = 1. / (1. + @compat(exp.(-n)))
+relu(x) = log.(1.0 .+ exp.(x))
+sigmoid(n) = 1. / (1. + exp.(-n))
 neural_step(x1, w1, w2) = sigmoid(dot(w2[1:size(w1, 2)], relu(w1 * x1[1:size(w1, 2)])))
 
 ################################

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+RealInterface
+SpecialFunctions

--- a/test/RulesTests.jl
+++ b/test/RulesTests.jl
@@ -25,11 +25,11 @@ for f in vcat(RealInterface.BINARY_SPECIAL_MATH, RealInterface.BINARY_ARITHMETIC
     if !(in(f, DiffBase.TODO))
         derivs = DiffRule{f}(:x, :y)
         @eval begin
-            x, y = rand(2)
+            x, y = rand(1:10), rand()
             dx, dy = $(derivs[1]), $(derivs[2])
 
             if !(isnan(dx))
-                @test isapprox(dx, finitediff(z -> $f(z, y), x), rtol=0.05)
+                @test isapprox(dx, finitediff(z -> $f(z, y), float(x)), rtol=0.05)
             end
 
             if !(isnan(dy))

--- a/test/RulesTests.jl
+++ b/test/RulesTests.jl
@@ -1,0 +1,42 @@
+using Base.Test
+using RealInterface
+using SpecialFunctions
+using DiffBase: DiffRule
+
+srand(1)
+
+function finitediff(f, x)
+    ϵ = cbrt(eps(typeof(x))) * max(one(typeof(x)), abs(x))
+    return (f(x + ϵ) - f(x - ϵ)) / (ϵ + ϵ)
+end
+
+for f in RealInterface.UNARY_ARITHMETIC
+    if !(in(f, DiffBase.TODO))
+        deriv = DiffRule{f}(:x)
+        @eval begin
+            x = rand()
+            @test isapprox($deriv, finitediff($f, x), rtol=0.05)
+        end
+    end
+end
+
+for f in RealInterface.UNARY_MATH
+    if !(in(f, DiffBase.TODO))
+        deriv = DiffRule{f}(:x)
+        modifier = in(f, (:asec, :acsc, :asecd, :acscd, :acosh, :acoth)) ? 1 : 0
+        @eval begin
+            x = rand() + $modifier
+            @test isapprox($deriv, finitediff($f, x), rtol=0.05)
+        end
+    end
+end
+
+for f in RealInterface.UNARY_SPECIAL_MATH
+    if !(in(f, DiffBase.TODO))
+        deriv = DiffRule{f}(:x)
+        @eval begin
+            x = rand()
+            @test isapprox($deriv, finitediff($f, x), rtol=0.05)
+        end
+    end
+end

--- a/test/RulesTests.jl
+++ b/test/RulesTests.jl
@@ -1,7 +1,7 @@
 using Base.Test
 using RealInterface
 using SpecialFunctions
-using DiffBase: DiffRule
+using DiffBase
 
 srand(1)
 
@@ -11,8 +11,8 @@ function finitediff(f, x)
 end
 
 for f in vcat(RealInterface.UNARY_ARITHMETIC, RealInterface.UNARY_MATH, RealInterface.UNARY_SPECIAL_MATH)
-    if !(in(f, DiffBase.TODO))
-        deriv = DiffRule{f}(:x)
+    if DiffBase.hasdiffrule(f, 1)
+        deriv = DiffBase.diffrule(f, :x)
         modifier = in(f, (:asec, :acsc, :asecd, :acscd, :acosh, :acoth)) ? 1 : 0
         @eval begin
             x = rand() + $modifier
@@ -21,9 +21,9 @@ for f in vcat(RealInterface.UNARY_ARITHMETIC, RealInterface.UNARY_MATH, RealInte
     end
 end
 
-for f in vcat(RealInterface.BINARY_SPECIAL_MATH, RealInterface.BINARY_ARITHMETIC)
-    if !(in(f, DiffBase.TODO))
-        derivs = DiffRule{f}(:x, :y)
+for f in vcat(RealInterface.BINARY_MATH, RealInterface.BINARY_ARITHMETIC, RealInterface.BINARY_SPECIAL_MATH)
+    if DiffBase.hasdiffrule(f, 2)
+        derivs = DiffBase.diffrule(f, :x, :y)
         @eval begin
             x, y = rand(1:10), rand()
             dx, dy = $(derivs[1]), $(derivs[2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,3 @@
 include("ResultTests.jl")
 include("TestFuncTests.jl")
+include("RulesTests.jl")


### PR DESCRIPTION
This PR ports over a refactored version of [the derivative rules currently provided by the Calculus package](https://github.com/johnmyleswhite/Calculus.jl/blob/master/src/differentiate.jl).

The benefits here are:

- adding an n-ary derivative rule is now as simple as adding unary rules
- linear algebra rules could easily be added in the future
- looking up rules is simpler for downstream differentiation implementations
- decoupling from downstream differentiation implementations should make this more maintainable

Because ForwardDiff (and soon, ReverseDiff) is dropping v0.5 support in the next release, this PR also drops v0.5 support to make sure that we don't run into a situation like https://github.com/JuliaDiff/ForwardDiff.jl/pull/205 again.