### PR TITLE
allow for immutable DiffResults to support totally stack-allocated computations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6-
+StaticArrays 0.5.0

--- a/src/DiffBase.jl
+++ b/src/DiffBase.jl
@@ -2,6 +2,8 @@ __precompile__()
 
 module DiffBase
 
+using StaticArrays
+
 include("results.jl")
 include("testfuncs.jl")
 include("rules.jl")

--- a/src/results.jl
+++ b/src/results.jl
@@ -1,57 +1,78 @@
-##############
-# DiffResult #
-##############
+#########
+# Types #
+#########
 
-mutable struct DiffResult{O,V,D<:Tuple}
+abstract type DiffResult{O,V,D<:Tuple} end
+
+struct ImmutableDiffResult{O,V,D<:Tuple} <: DiffResult{O,V,D}
     value::V
     derivs::D # ith element = ith-order derivative
-    function DiffResult{O,V,D}(value::V, derivs::NTuple{O,Any}) where {O,V,D}
-        return new{O,V,D}(value, derivs)
+    function ImmutableDiffResult(value::V, derivs::NTuple{O,Any}) where {O,V}
+        return new{O,V,typeof(derivs)}(value, derivs)
     end
 end
 
-"""
-    DiffResult(value, derivs::Tuple)
+mutable struct MutableDiffResult{O,V,D<:Tuple} <: DiffResult{O,V,D}
+    value::V
+    derivs::D # ith element = ith-order derivative
+    function MutableDiffResult(value::V, derivs::NTuple{O,Any}) where {O,V}
+        return new{O,V,typeof(derivs)}(value, derivs)
+    end
+end
 
-Return a `DiffResult` instance where values will be stored in the provided `value` storage
-and derivatives will be stored in the provided `derivs` storage.
-
-Note that the arguments can be `Number`s or `AbstractArray`s, depending on the dimensionality
-of your target function.
-"""
-DiffResult{V,O}(value::V, derivs::NTuple{O,Any}) = DiffResult{O,V,typeof(derivs)}(value, derivs)
+################
+# Constructors #
+################
 
 """
-    DiffResult(value, derivs...)
+    DiffResult(value::Union{Number,AbstractArray}, derivs::Tuple{Vararg{Number}})
+    DiffResult(value::Union{Number,AbstractArray}, derivs::Tuple{Vararg{AbstractArray}})
 
-Equivalent to `DiffResult(value, derivs::Tuple)`, where `derivs...` is the splatted form of `derivs::Tuple`.
+Return `r::DiffResult`, with output value storage provided by `value` and output derivative
+storage provided by `derivs`.
+
+In reality, `DiffResult` is an abstract supertype of two concrete types, `MutableDiffResult`
+and `ImmutableDiffResult`. If all `value`/`derivs` are all `Number`s or `SArray`s, then `r`
+will be immutable (i.e. `r::ImmutableDiffResult`). Otherwise, `r` will be mutable
+(i.e. `r::MutableDiffResult`).
+
+Note that `derivs` can be provide in splatted form, i.e. `DiffResult(value, derivs...)`.
 """
-DiffResult(value, derivs...) = DiffResult(value, derivs)
+DiffResult
+
+DiffResult(value::Number, derivs::Tuple{Vararg{Number}}) = ImmutableDiffResult(value, derivs)
+DiffResult(value::Number, derivs::Tuple{Vararg{SArray}}) = ImmutableDiffResult(value, derivs)
+DiffResult(value::SArray, derivs::Tuple{Vararg{SArray}}) = ImmutableDiffResult(value, derivs)
+DiffResult(value::Number, derivs::Tuple{Vararg{AbstractArray}}) = MutableDiffResult(value, derivs)
+DiffResult(value::AbstractArray, derivs::Tuple{Vararg{AbstractArray}}) = MutableDiffResult(value, derivs)
+DiffResult(value::Union{Number,AbstractArray}, derivs::Union{Number,AbstractArray}...) = DiffResult(value, derivs)
 
 """
     GradientResult(x::AbstractArray)
 
-Construct a `DiffResult` that can be used for gradient calculations where `x` is the
-input to the target function.
+Construct a `DiffResult` that can be used for gradient calculations where `x` is the input
+to the target function.
 
 Note that `GradientResult` allocates its own storage; `x` is only used for type and
 shape information. If you want to allocate storage yourself, use the `DiffResult`
 constructor instead.
 """
 GradientResult(x::AbstractArray) = DiffResult(first(x), similar(x))
+GradientResult(x::SArray) = DiffResult(first(x), x)
 
 """
     JacobianResult(x::AbstractArray)
 
-Construct a `DiffResult` that can be used for Jacobian calculations where `x` is the
-input to the target function. This method assumes that the target function's output
-dimension equals its input dimension.
+Construct a `DiffResult` that can be used for Jacobian calculations where `x` is the input
+to the target function. This method assumes that the target function's output dimension
+equals its input dimension.
 
 Note that `JacobianResult` allocates its own storage; `x` is only used for type and
 shape information. If you want to allocate storage yourself, use the `DiffResult`
 constructor instead.
 """
 JacobianResult(x::AbstractArray) = DiffResult(similar(x), similar(x, length(x), length(x)))
+JacobianResult(x::SArray{<:Any,T,<:Any,L}) where {T,L} = DiffResult(x, zeros(SMatrix{L,L,T}))
 
 """
     JacobianResult(y::AbstractArray, x::AbstractArray)
@@ -64,6 +85,7 @@ Like the single argument version, `y` and `x` are only used for type and
 shape information and are not stored in the returned `DiffResult`.
 """
 JacobianResult(y::AbstractArray, x::AbstractArray) = DiffResult(similar(y), similar(y, length(y), length(x)))
+JacobianResult(y::SArray{<:Any,<:Any,<:Any,Y}, x::SArray{<:Any,T,<:Any,X}) where {T,Y,X} = DiffResult(y, zeros(SMatrix{Y,X,T}))
 
 """
     HessianResult(x::AbstractArray)
@@ -76,9 +98,30 @@ shape information. If you want to allocate storage yourself, use the `DiffResult
 constructor instead.
 """
 HessianResult(x::AbstractArray) = DiffResult(first(x), similar(x), similar(x, length(x), length(x)))
+HessianResult(x::SArray{<:Any,T,<:Any,L}) where {T,L} = DiffResult(first(x), x, zeros(SMatrix{L,L,T}))
+
+#############
+# Interface #
+#############
+
+@generated function tuple_eltype(x::Tuple, ::Type{Val{i}}) where {i}
+    return quote
+        $(Expr(:meta, :inline))
+        return $(x.parameters[i])
+    end
+end
+
+@generated function tuple_setindex(x::NTuple{N,Any}, y, ::Type{Val{i}}) where {N,i}
+    new_tuple = Expr(:tuple, [ifelse(i == n, :y, :(x[$n])) for n in 1:N]...)
+    return quote
+        $(Expr(:meta, :inline))
+        return $new_tuple
+    end
+end
 
 Base.eltype(r::DiffResult) = eltype(typeof(r))
-Base.eltype{O,V,D}(::Type{DiffResult{O,V,D}}) = eltype(V)
+
+Base.eltype(::Type{D}) where {O,V,D<:DiffResult{O,V}} = eltype(V)
 
 Base.:(==)(a::DiffResult, b::DiffResult) = a.value == b.value && a.derivs == b.derivs
 
@@ -92,26 +135,35 @@ Base.copy(r::DiffResult) = DiffResult(copy(r.value), map(copy, r.derivs))
 
 Return the primal value stored in `r`.
 
-Note that this method returns a reference, not a copy. Thus, if `value(r)` is mutable,
-mutating `value(r)` will mutate `r`.
+Note that this method returns a reference, not a copy.
 """
 value(r::DiffResult) = r.value
 
 """
     value!(r::DiffResult, x)
 
-Copy `x` into `r`'s value storage, such that `value(r) == x`.
+Return `s::DiffResult` with the same data as `r`, except for `value(s) == x`.
+
+This function may or may not mutate `r`. If `r::ImmutableDiffResult`, a totally new
+instance will be created and returned, whereas if `r::MutableDiffResult`, then `r` will be
+mutated in-place and returned. Thus, this function should be called as `r = value!(r, x)`.
 """
-value!(r::DiffResult, x::Number) = (r.value = x; return r)
-value!(r::DiffResult, x::AbstractArray) = (copy!(value(r), x); return r)
+value!(r::MutableDiffResult, x::Number) = (r.value = x; return r)
+value!(r::MutableDiffResult, x::AbstractArray) = (copy!(value(r), x); return r)
+value!(r::ImmutableDiffResult, x::Union{Number,SArray}) = ImmutableDiffResult(x, r.derivs)
+value!(r::ImmutableDiffResult, x::AbstractArray) = ImmutableDiffResult(typeof(value(r))(x), r.derivs)
 
 """
     value!(f, r::DiffResult, x)
 
-Like `value!(r::DiffResult, x)`, but with `f` applied to each element, such that `value(r) == map(f, x)`.
+Equivalent to `value!(r::DiffResult, map(f, x))`, but without the implied temporary
+allocation (when possible).
 """
-value!(f, r::DiffResult, x::Number) = (r.value = f(x); return r)
-value!(f, r::DiffResult, x::AbstractArray) = (map!(f, value(r), x); return r)
+value!(f, r::MutableDiffResult, x::Number) = (r.value = f(x); return r)
+value!(f, r::MutableDiffResult, x::AbstractArray) = (map!(f, value(r), x); return r)
+value!(f, r::ImmutableDiffResult, x::Number) = value!(r, f(x))
+value!(f, r::ImmutableDiffResult, x::SArray) = value!(r, map(f, x))
+value!(f, r::ImmutableDiffResult, x::AbstractArray) = value!(r, map(f, typeof(value(r))(x)))
 
 # derivative/derivative! #
 #------------------------#
@@ -121,46 +173,66 @@ value!(f, r::DiffResult, x::AbstractArray) = (map!(f, value(r), x); return r)
 
 Return the `ith` derivative stored in `r`, defaulting to the first derivative.
 
-Note that this method returns a reference, not a copy. Thus, if `derivative(r)` is mutable,
-mutating `derivative(r)` will mutate `r`.
+Note that this method returns a reference, not a copy.
 """
-derivative{i}(r::DiffResult, ::Type{Val{i}} = Val{1}) = r.derivs[i]
+derivative(r::DiffResult, ::Type{Val{i}} = Val{1}) where {i} = r.derivs[i]
 
 """
     derivative!(r::DiffResult, x, ::Type{Val{i}} = Val{1})
 
-Copy `x` into `r`'s `ith` derivative storage, such that `derivative(r, Val{i}) == x`.
+Return `s::DiffResult` with the same data as `r`, except `derivative(s, Val{i}) == x`.
+
+This function may or may not mutate `r`. If `r::ImmutableDiffResult`, a totally new
+instance will be created and returned, whereas if `r::MutableDiffResult`, then `r` will be
+mutated in-place and returned. Thus, this function should be called as
+`r = derivative!(r, x, Val{i})`.
 """
-@generated function derivative!{O,i}(r::DiffResult{O}, x::Number, ::Type{Val{i}} = Val{1})
-    newderivs = Expr(:tuple, [i == n ? :(x) : :(derivative(r, Val{$n})) for n in 1:O]...)
-    return quote
-        r.derivs = $newderivs
-        return r
-    end
+function derivative!(r::MutableDiffResult, x::Number, ::Type{Val{i}} = Val{1}) where {i}
+    r.derivs = tuple_setindex(r.derivs, x, Val{i})
+    return r
 end
 
-function derivative!{i}(r::DiffResult, x::AbstractArray, ::Type{Val{i}} = Val{1})
+function derivative!(r::MutableDiffResult, x::AbstractArray, ::Type{Val{i}} = Val{1}) where {i}
     copy!(derivative(r, Val{i}), x)
     return r
+end
+
+function derivative!(r::ImmutableDiffResult, x::Union{Number,SArray}, ::Type{Val{i}} = Val{1}) where {i}
+    return ImmutableDiffResult(value(r), tuple_setindex(r.derivs, x, Val{i}))
+end
+
+function derivative!(r::ImmutableDiffResult, x::AbstractArray, ::Type{Val{i}} = Val{1}) where {i}
+    T = tuple_eltype(r.derivs, Val{i})
+    return ImmutableDiffResult(value(r), tuple_setindex(r.derivs, T(x), Val{i}))
 end
 
 """
     derivative!(f, r::DiffResult, x, ::Type{Val{i}} = Val{1})
 
-Like `derivative!(r::DiffResult, x, Val{i})`, but with `f` applied to each element,
-such that `derivative(r, Val{i}) == map(f, x)`.
+Equivalent to `derivative!(r::DiffResult, map(f, x), Val{i})`, but without the implied
+temporary allocation (when possible).
 """
-@generated function derivative!{O,i}(f, r::DiffResult{O}, x::Number, ::Type{Val{i}} = Val{1})
-    newderivs = Expr(:tuple, [i == n ? :(f(x)) : :(derivative(r, Val{$n})) for n in 1:O]...)
-    return quote
-        r.derivs = $newderivs
-        return r
-    end
+function derivative!(f, r::MutableDiffResult, x::Number, ::Type{Val{i}} = Val{1}) where {i}
+    r.derivs = tuple_setindex(r.derivs, f(x), Val{i})
+    return r
 end
 
-function derivative!{i}(f, r::DiffResult, x::AbstractArray, ::Type{Val{i}} = Val{1})
+function derivative!(f, r::MutableDiffResult, x::AbstractArray, ::Type{Val{i}} = Val{1}) where {i}
     map!(f, derivative(r, Val{i}), x)
     return r
+end
+
+function derivative!(f, r::ImmutableDiffResult, x::Number, ::Type{Val{i}} = Val{1}) where {i}
+    return derivative!(r, f(x), Val{i})
+end
+
+function derivative!(f, r::ImmutableDiffResult, x::SArray, ::Type{Val{i}} = Val{1}) where {i}
+    return derivative!(r, map(f, x), Val{i})
+end
+
+function derivative!(f, r::ImmutableDiffResult, x::AbstractArray, ::Type{Val{i}} = Val{1}) where {i}
+    T = tuple_eltype(r.derivs, Val{i})
+    return derivative!(r, map(f, T(x)), Val{i})
 end
 
 # special-cased methods #
@@ -169,74 +241,91 @@ end
 """
     gradient(r::DiffResult)
 
-Return the gradient stored in `r` (equivalent to `derivative(r)`).
+Return the gradient stored in `r`.
 
-Note that this method returns a reference, not a copy. Thus, if `gradient(r)` is mutable,
-mutating `gradient(r)` will mutate `r`.
+Equivalent to `derivative(r, Val{1})`; see `derivative` docs for aliasing behavior.
 """
 gradient(r::DiffResult) = derivative(r)
 
 """
     gradient!(r::DiffResult, x)
 
-Copy `x` into `r`'s gradient storage, such that `gradient(r) == x`.
+Return `s::DiffResult` with the same data as `r`, except `gradient(s) == x`.
+
+Equivalent to `derivative!(r, x, Val{1})`; see `derivative!` docs for aliasing behavior.
 """
 gradient!(r::DiffResult, x) = derivative!(r, x)
 
 """
     gradient!(f, r::DiffResult, x)
 
-Like `gradient!(r::DiffResult, x)`, but with `f` applied to each element,
-such that `gradient(r) == map(f, x)`.
+Equivalent to `gradient!(r::DiffResult, map(f, x))`, but without the implied temporary
+allocation (when possible).
+
+Equivalent to `derivative!(f, r, x, Val{1})`; see `derivative!` docs for aliasing behavior.
 """
 gradient!(f, r::DiffResult, x) = derivative!(f, r, x)
 
 """
     jacobian(r::DiffResult)
 
-Return the Jacobian stored in `r` (equivalent to `derivative(r)`).
+Return the Jacobian stored in `r`.
 
-Note that this method returns a reference, not a copy. Thus, if `jacobian(r)` is mutable,
-mutating `jacobian(r)` will mutate `r`.
+Equivalent to `derivative(r, Val{1})`; see `derivative` docs for aliasing behavior.
 """
 jacobian(r::DiffResult) = derivative(r)
 
 """
     jacobian!(r::DiffResult, x)
 
-Copy `x` into `r`'s Jacobian storage, such that `jacobian(r) == x`.
+Return `s::DiffResult` with the same data as `r`, except `jacobian(s) == x`.
+
+Equivalent to `derivative!(r, x, Val{1})`; see `derivative!` docs for aliasing behavior.
 """
 jacobian!(r::DiffResult, x) = derivative!(r, x)
 
 """
     jacobian!(f, r::DiffResult, x)
 
-Like `jacobian!(r::DiffResult, x)`, but with `f` applied to each element,
-such that `jacobian(r) == map(f, x)`.
+Equivalent to `jacobian!(r::DiffResult, map(f, x))`, but without the implied temporary
+allocation (when possible).
+
+Equivalent to `derivative!(f, r, x, Val{1})`; see `derivative!` docs for aliasing behavior.
 """
 jacobian!(f, r::DiffResult, x) = derivative!(f, r, x)
 
 """
     hessian(r::DiffResult)
 
-Return the Hessian stored in `r` (equivalent to `derivative(r, Val{2})`).
+Return the Hessian stored in `r`.
 
-Note that this method returns a reference, not a copy. Thus, if `hessian(r)` is mutable,
-mutating `hessian(r)` will mutate `r`.
+Equivalent to `derivative(r, Val{2})`; see `derivative` docs for aliasing behavior.
 """
 hessian(r::DiffResult) = derivative(r, Val{2})
 
 """
     hessian!(r::DiffResult, x)
 
-Copy `x` into `r`'s Hessian storage, such that `hessian(r) == x`.
+Return `s::DiffResult` with the same data as `r`, except `hessian(s) == x`.
+
+Equivalent to `derivative!(r, x, Val{2})`; see `derivative!` docs for aliasing behavior.
 """
 hessian!(r::DiffResult, x) = derivative!(r, x, Val{2})
 
 """
     hessian!(f, r::DiffResult, x)
 
-Like `hessian!(r::DiffResult, x)`, but with `f` applied to each element,
-such that `hessian(r) == map(f, x)`.
+Equivalent to `hessian!(r::DiffResult, map(f, x))`, but without the implied temporary
+allocation (when possible).
+
+Equivalent to `derivative!(f, r, x, Val{2})`; see `derivative!` docs for aliasing behavior.
 """
 hessian!(f, r::DiffResult, x) = derivative!(f, r, x, Val{2})
+
+###################
+# Pretty Printing #
+###################
+
+Base.show(io::IO, r::ImmutableDiffResult) = print(io, "ImmutableDiffResult($(r.value), $(r.derivs))")
+
+Base.show(io::IO, r::MutableDiffResult) = print(io, "MutableDiffResult($(r.value), $(r.derivs))")

--- a/test/ResultTests.jl
+++ b/test/ResultTests.jl
@@ -3,14 +3,20 @@ module ResultTests
 using DiffBase
 using Base.Test
 
+using StaticArrays
+
 using DiffBase: DiffResult, GradientResult, JacobianResult, HessianResult,
                 value, value!, derivative, derivative!, gradient, gradient!,
                 jacobian, jacobian!, hessian, hessian!
 
-const k = 3
-const n0, n1, n2 = rand(), rand(), rand()
-const x0, x1, x2 = rand(k), rand(k, k), rand(k, k, k)
-const rn, rx = DiffResult(n0, n1, n2), DiffResult(x0, x1, x2)
+k = 3
+n0, n1, n2 = rand(), rand(), rand()
+x0, x1, x2 = rand(k), rand(k, k), rand(k, k, k)
+s0, s1, s2 = SVector{k}(rand(k)), SMatrix{k,k}(rand(k, k)), SArray{Tuple{k,k,k}}(rand(k, k, k))
+rn = DiffResult(n0, n1, n2)
+rx = DiffResult(x0, x1, x2)
+rs = DiffResult(s0, s1, s2)
+rsmix = DiffResult(n0, s0, s1)
 
 issimilar(x, y) = typeof(x) == typeof(y) && size(x) == size(y)
 issimilar(x::DiffResult, y::DiffResult) = issimilar(value(x), value(y)) && all(issimilar, zip(x.derivs, y.derivs))
@@ -20,48 +26,86 @@ issimilar(t::Tuple) = issimilar(t...)
 # DiffResult #
 ##############
 
-@test rn == DiffResult(n0, n1, n2)
+@test rn === DiffResult(n0, n1, n2)
 @test rx == DiffResult(x0, x1, x2)
+@test rs === DiffResult(s0, s1, s2)
+@test rsmix === DiffResult(n0, s0, s1)
 
 @test issimilar(GradientResult(x0), DiffResult(first(x0), x0))
 @test issimilar(JacobianResult(x0), DiffResult(x0, similar(x0, k, k)))
 @test issimilar(JacobianResult(similar(x0, k + 1), x0), DiffResult(similar(x0, k + 1), similar(x0, k + 1, k)))
 @test issimilar(HessianResult(x0), DiffResult(first(x0), x0, similar(x0, k, k)))
 
+@test GradientResult(s0) === DiffResult(first(s0), s0)
+@test JacobianResult(s0) === DiffResult(s0, zeros(SMatrix{k,k,Float64}))
+@test JacobianResult(SVector{k+1}(vcat(s0, 0.0)), s0) === DiffResult(SVector{k+1}(vcat(s0, 0.0)), zeros(SMatrix{k+1,k,Float64}))
+@test HessianResult(s0) === DiffResult(first(s0), s0, zeros(SMatrix{k,k,Float64}))
+
 @test eltype(rn) === typeof(n0)
 @test eltype(rx) === eltype(x0)
+@test eltype(rs) === eltype(s0)
 
 rn_copy = copy(rn)
 @test rn == rn_copy
-@test rn !== rn_copy
+@test rn === rn_copy
 
 rx_copy = copy(rx)
 @test rx == rx_copy
 @test rx !== rx_copy
+
+rs_copy = copy(rs)
+@test rs == rs_copy
+@test rs === rs_copy
+
+rsmix_copy = copy(rsmix)
+@test rsmix == rsmix_copy
+@test rsmix === rsmix_copy
 
 # value/value! #
 #--------------#
 
 @test value(rn) === n0
 @test value(rx) === x0
+@test value(rs) === s0
+@test value(rsmix) === n0
 
-value!(rn, n1)
+rn = value!(rn, n1)
 @test value(rn) === n1
-value!(rn, n0)
+rn = value!(rn, n0)
 
 x0_new, x0_copy = rand(k), copy(x0)
-value!(rx, x0_new)
+rx = value!(rx, x0_new)
 @test value(rx) === x0 == x0_new
-value!(rx, x0_copy)
+rx = value!(rx, x0_copy)
 
-value!(exp, rn, n1)
+s0_new = rand(k)
+rs = value!(rs, s0_new)
+@test value(rs) == s0_new
+@test typeof(value(rs)) === typeof(s0)
+rs = value!(rs, s0)
+
+rsmix = value!(rsmix, n1)
+@test value(rsmix) === n1
+rsmix = value!(rsmix, n0)
+
+rn = value!(exp, rn, n1)
 @test value(rn) === exp(n1)
-value!(rn, n0)
+rn = value!(rn, n0)
 
 x0_new, x0_copy = rand(k), copy(x0)
-value!(exp, rx, x0_new)
+rx = value!(exp, rx, x0_new)
 @test value(rx) === x0 == exp.(x0_new)
-value!(rx, x0_copy)
+rx = value!(rx, x0_copy)
+
+s0_new = rand(k)
+rs = value!(exp, rs, s0_new)
+@test value(rs) == exp.(s0_new)
+@test typeof(value(rs)) === typeof(s0)
+rs = value!(rs, s0)
+
+rsmix = value!(exp, rsmix, n1)
+@test value(rsmix) === exp(n1)
+rsmix = value!(rsmix, n0)
 
 # derivative/derivative! #
 #------------------------#
@@ -72,79 +116,169 @@ value!(rx, x0_copy)
 @test derivative(rx) === x1
 @test derivative(rx, Val{2}) === x2
 
-derivative!(rn, n0)
+@test derivative(rs) === s1
+@test derivative(rs, Val{2}) === s2
+
+@test derivative(rsmix) === s0
+@test derivative(rsmix, Val{2}) === s1
+
+rn = derivative!(rn, n0)
 @test derivative(rn) === n0
-derivative!(rn, n1)
+rn = derivative!(rn, n1)
 
 x1_new, x1_copy = rand(k, k), copy(x1)
-derivative!(rx, x1_new)
+rx = derivative!(rx, x1_new)
 @test derivative(rx) === x1 == x1_new
-derivative!(rx, x1_copy)
+rx = derivative!(rx, x1_copy)
 
-derivative!(rn, n1, Val{2})
+s1_new = rand(k, k)
+rs = derivative!(rs, s1_new)
+@test derivative(rs) == s1_new
+@test typeof(derivative(rs)) === typeof(s1)
+rs = derivative!(rs, s1)
+
+s0_new = rand(k)
+rsmix = derivative!(rsmix, s0_new)
+@test derivative(rsmix) == s0_new
+@test typeof(derivative(rsmix)) === typeof(s0)
+rsmix = derivative!(rsmix, s0)
+
+rn = derivative!(rn, n1, Val{2})
 @test derivative(rn, Val{2}) === n1
-derivative!(rn, n2, Val{2})
+rn = derivative!(rn, n2, Val{2})
 
 x2_new, x2_copy = rand(k, k, k), copy(x2)
-derivative!(rx, x2_new, Val{2})
+rx = derivative!(rx, x2_new, Val{2})
 @test derivative(rx, Val{2}) === x2 == x2_new
-derivative!(rx, x2_copy, Val{2})
+rx = derivative!(rx, x2_copy, Val{2})
 
-derivative!(exp, rn, n0)
+s2_new = rand(k, k, k)
+rs = derivative!(rs, s2_new, Val{2})
+@test derivative(rs, Val{2}) == s2_new
+@test typeof(derivative(rs, Val{2})) === typeof(s2)
+rs = derivative!(rs, s2, Val{2})
+
+s1_new = rand(k, k)
+rsmix = derivative!(rsmix, s1_new, Val{2})
+@test derivative(rsmix, Val{2}) == s1_new
+@test typeof(derivative(rsmix, Val{2})) === typeof(s1)
+rsmix = derivative!(rsmix, s1, Val{2})
+
+rn = derivative!(exp, rn, n0)
 @test derivative(rn) === exp(n0)
-derivative!(rn, n1)
+rn = derivative!(rn, n1)
 
 x1_new, x1_copy = rand(k, k), copy(x1)
-derivative!(exp, rx, x1_new)
+rx = derivative!(exp, rx, x1_new)
 @test derivative(rx) === x1 == exp.(x1_new)
-derivative!(exp, rx, x1_copy)
+rx = derivative!(exp, rx, x1_copy)
 
-derivative!(exp, rn, n1, Val{2})
+s1_new = rand(k, k)
+rs = derivative!(exp, rs, s1_new)
+@test derivative(rs) == exp.(s1_new)
+@test typeof(derivative(rs)) === typeof(s1)
+rs = derivative!(exp, rs, s1)
+
+s0_new = rand(k)
+rsmix = derivative!(exp, rsmix, s0_new)
+@test derivative(rsmix) == exp.(s0_new)
+@test typeof(derivative(rsmix)) === typeof(s0)
+rsmix = derivative!(exp, rsmix, s0)
+
+rn = derivative!(exp, rn, n1, Val{2})
 @test derivative(rn, Val{2}) === exp(n1)
-derivative!(rn, n2, Val{2})
+rn = derivative!(rn, n2, Val{2})
 
 x2_new, x2_copy = rand(k, k, k), copy(x2)
-derivative!(exp, rx, x2_new, Val{2})
+rx = derivative!(exp, rx, x2_new, Val{2})
 @test derivative(rx, Val{2}) === x2 == exp.(x2_new)
-derivative!(exp, rx, x2_copy, Val{2})
+rx = derivative!(exp, rx, x2_copy, Val{2})
+
+s2_new = rand(k, k, k)
+rs = derivative!(exp, rs, s2_new, Val{2})
+@test derivative(rs, Val{2}) == exp.(s2_new)
+@test typeof(derivative(rs, Val{2})) === typeof(s2)
+rs = derivative!(exp, rs, s2, Val{2})
+
+s1_new = rand(k, k)
+rsmix = derivative!(exp, rsmix, s1_new, Val{2})
+@test derivative(rsmix, Val{2}) == exp.(s1_new)
+@test typeof(derivative(rsmix, Val{2})) === typeof(s1)
+rsmix = derivative!(exp, rsmix, s1, Val{2})
 
 # gradient/gradient! #
 #--------------------#
 
 x1_new, x1_copy = rand(k, k), copy(x1)
-gradient!(rx, x1_new)
+rx = gradient!(rx, x1_new)
 @test gradient(rx) === x1 == x1_new
-gradient!(rx, x1_copy)
+rx = gradient!(rx, x1_copy)
+
+s1_new = rand(k, k)
+rs = gradient!(rs, s1_new)
+@test gradient(rs) == s1_new
+@test typeof(gradient(rs)) === typeof(s1)
+rs = gradient!(rs, s1)
 
 x1_new, x1_copy = rand(k, k), copy(x1)
-gradient!(exp, rx, x1_new)
+rx = gradient!(exp, rx, x1_new)
 @test gradient(rx) === x1 == exp.(x1_new)
-gradient!(exp, rx, x1_copy)
+rx = gradient!(exp, rx, x1_copy)
+
+s0_new = rand(k)
+rsmix = gradient!(exp, rsmix, s0_new)
+@test gradient(rsmix) == exp.(s0_new)
+@test typeof(gradient(rsmix)) === typeof(s0)
+rsmix = gradient!(exp, rsmix, s0)
 
 # jacobian/jacobian! #
 #--------------------#
 
 x1_new, x1_copy = rand(k, k), copy(x1)
-jacobian!(rx, x1_new)
+rx = jacobian!(rx, x1_new)
 @test jacobian(rx) === x1 == x1_new
-jacobian!(rx, x1_copy)
+rx = jacobian!(rx, x1_copy)
+
+s1_new = rand(k, k)
+rs = jacobian!(rs, s1_new)
+@test jacobian(rs) == s1_new
+@test typeof(jacobian(rs)) === typeof(s1)
+rs = jacobian!(rs, s1)
 
 x1_new, x1_copy = rand(k, k), copy(x1)
-jacobian!(exp, rx, x1_new)
+rx = jacobian!(exp, rx, x1_new)
 @test jacobian(rx) === x1 == exp.(x1_new)
-jacobian!(exp, rx, x1_copy)
+rx = jacobian!(exp, rx, x1_copy)
+
+s0_new = rand(k)
+rsmix = jacobian!(exp, rsmix, s0_new)
+@test jacobian(rsmix) == exp.(s0_new)
+@test typeof(jacobian(rsmix)) === typeof(s0)
+rsmix = jacobian!(exp, rsmix, s0)
 
 # hessian/hessian! #
 #------------------#
 
 x2_new, x2_copy = rand(k, k, k), copy(x2)
-hessian!(rx, x2_new)
+rx = hessian!(rx, x2_new)
 @test hessian(rx) === x2 == x2_new
-hessian!(rx, x2_copy)
+rx = hessian!(rx, x2_copy)
+
+s2_new = rand(k, k, k)
+rs = hessian!(rs, s2_new)
+@test hessian(rs) == s2_new
+@test typeof(hessian(rs)) === typeof(s2)
+rs = hessian!(rs, s2)
 
 x2_new, x2_copy = rand(k, k, k), copy(x2)
-hessian!(exp, rx, x2_new)
+rx = hessian!(exp, rx, x2_new)
 @test hessian(rx) === x2 == exp.(x2_new)
-hessian!(exp, rx, x2_copy)
+rx = hessian!(exp, rx, x2_copy)
+
+s1_new = rand(k, k)
+rsmix = hessian!(exp, rsmix, s1_new)
+@test hessian(rsmix) == exp.(s1_new)
+@test typeof(hessian(rsmix)) === typeof(s1)
+rsmix = hessian!(exp, rsmix, s1)
 
 end # module


### PR DESCRIPTION
ref https://github.com/JuliaDiff/ForwardDiff.jl/pull/224, cc @aaowens

This PR makes `DiffResult` an abstract type with two concrete subtypes, `ImmutableDiffResult` and `MutableDiffResult`. 

Methods that were previously *always* mutating are now only *sometimes* mutating. I've updated the docs to mandate that all calls to such functions should assign output to the input binding, in order to maintain correctness regardless of the mutability behavior. For example:

```julia
julia> using DiffBase, StaticArrays

julia> v, d, sd = rand(), rand(3), SVector{3}(rand(3));

# DiffResult(args...) where args aren't Numbers/SArrays returns a MutableDiffResult
julia> r = DiffBase.DiffResult(v, d)
MutableDiffResult(0.019792139758717964, ([0.57343, 0.304741, 0.851931],))

# I'm reassigning `r` for good style, but note that it's actually being mutated
julia> r = DiffBase.value!(r, rand())
MutableDiffResult(0.3288994147732498, ([0.57343, 0.304741, 0.851931],))

# DiffResult(args...) where args are only Numbers/SArrays returns an ImmutableDiffResult
julia> sr = DiffBase.DiffResult(v, sd)
ImmutableDiffResult(0.019792139758717964, ([0.70915, 0.188879, 0.235341],))

# Here, the reassignment is actually essential - `sr` isn't being mutated. Instead, a new instance is returned.
julia> sr = DiffBase.value!(sr, rand())
ImmutableDiffResult(0.5037751561923891, ([0.70915, 0.188879, 0.235341],))
```

The painful part of this is that we could get rid of `MutableDiffResult` entirely, if not for Julia's stack-unaware GC. We would just make `ImmutableDiffResult` the default, and always construct a new instance per method call. Mutable fields (e.g. `Array` fields) could be mutated/passed along to new instances, while immutable fields (`Number`/`SArray`) could be re-instantiated for free. It'd be less code, make the reassignment convention more enforceable, and would be just as performant...except Julia's GC heap-allocates any instances containing heap-allocated fields. Sigh. 

On a side note, https://github.com/JuliaLang/julia/pull/21912 would be really useful if we were able to take the immutable-by-default path.