### PR TITLE
Add rem2pi

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -165,6 +165,7 @@ hasdiffrule(f::Symbol, arity::Int) = in((f, arity), DEFINED_DIFFRULES)
 @define_diffrule hypot(x, y) = :($x / hypot($x, $y)), :($y / hypot($x, $y))
 @define_diffrule mod(x, y)   = :(first(promote(ifelse(isinteger($x / $y), NaN, 1), NaN))), :(z = $x / $y; first(promote(ifelse(isinteger(z), NaN, -floor(z)), NaN)))
 @define_diffrule rem(x, y)   = :(first(promote(ifelse(isinteger($x / $y), NaN, 1), NaN))), :(z = $x / $y; first(promote(ifelse(isinteger(z), NaN, -trunc(z)), NaN)))
+@define_diffrule rem2pi(x, r) = :(1), :NaN
 
 ####################
 # SpecialFunctions #

--- a/test/RulesTests.jl
+++ b/test/RulesTests.jl
@@ -38,3 +38,17 @@ for f in vcat(RealInterface.BINARY_MATH, RealInterface.BINARY_ARITHMETIC, RealIn
         end
     end
 end
+
+# Treat rem2pi separately because of its non-numeric second argument:
+derivs = DiffBase.diffrule(:rem2pi, :x, :y)
+for xtype in [:Float64, :BigFloat, :Int64]
+    for mode in [:RoundUp, :RoundDown, :RoundToZero, :RoundNearest]
+        @eval begin
+            x = $xtype(rand(1 : 10))
+            y = $mode
+            dx, dy = $(derivs[1]), $(derivs[2])
+            @test isapprox(dx, finitediff(z -> rem2pi(z, y), float(x)), rtol=0.05)
+            @test isnan(dy)
+        end
+    end
+end


### PR DESCRIPTION
Fixes #18.

Unlike `rem`, I don't think it makes sense to add `rem2pi` to [`RealInterface.BINARY_MATH`](https://github.com/jrevels/RealInterface.jl/blob/46364c40f658613605d5d265058ffab0cf5620f0/src/RealInterface.jl#L23), because e.g. https://github.com/JuliaDiff/ForwardDiff.jl/blob/18b46471e4bb3d36633058267606767246b3e931/src/dual.jl#L420 won't do the right thing for this case. Same thing for the standard tests in RulesTests.jl.

Please advise on how to handle this: should there be a new category in RealInterface containing only this function, or should this just be special cased directly in ForwardDiff and other RealInterface dependents?
